### PR TITLE
Host on github pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 JPEG Visual Repair Tool, based on [jpeg-decomp](https://github.com/albmac/jpeg-decomp), can load JPEG images while preserving MCU (Minimum Coded Unit) coding data and allows editing at MCU level; the main purpose is to repair corrupted images.
 It is written in JavaScript and resides in a single [html document](JPEGVisualRepairTool.html); it can be simply saved for offline use, there are no library dependencies.
+A live version of the most recent commit is hosted [here](https://albmac.github.io/JPEGVisualRepairTool/JPEGVisualRepairTool.html). Note that everything is done locally in the web browser, so no data is ever sent to the server hosting the html document.
 
 Using it you can:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # JPEG Visual Repair Tool
-<img src="JVRTmain.jpg" width="500"></img>
+<img src="JVRTmain.jpg" width="500" />
 
 JPEG Visual Repair Tool can load JPEG images while preserving MCU (Minimum Coded Unit) coding data and allows editing at MCU level; the main purpose is to repair corrupted images.
 It is written in JavaScript and resides in a single [html document](JPEGVisualRepairTool.html); it can be simply saved for offline use, there are no library dependencies. 
@@ -42,15 +42,15 @@ A crossed red rectangle appears on MCUs that produced decode errors.
 
 Corrupted images can be edited block by block (MCU) without losing information; even bright or dark areas still contain the original details. The problem often lies in the DC levels of specific MCUs.
 
-<img src="s1.jpg" width="400"></img>
+<img src="s1.jpg" width="400" />
 
 First align image features by deleting spurious MCUs (effect of corruption); the shift feature (s+arrows) comes handy in determining how many blocks to delete.
 
-<img src="s2.jpg" width="400"></img>
+<img src="s2.jpg" width="400" />
 
 Equalize colors either manually (DC+/DC- while viewing a single channel) or automatically (using __Fix colors__ on right-selected MCUs)
 
-<img src="s3.jpg" width="400"></img>
+<img src="s3.jpg" width="400" />
 
 Finally, save as a new image
 
@@ -58,4 +58,4 @@ For more details see the tutorial on [how to repair a corrupted JPEG image](Repa
 
 Or this video tutorial:
 
-[<img src="video1.jpg" width="500"></img>](https://www.youtube.com/watch?v=REYcgWHb33M&t=194s)
+[<img src="video1.jpg" width="500" />](https://www.youtube.com/watch?v=REYcgWHb33M&t=194s)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # JPEG Visual Repair Tool
 <img src="JVRTmain.jpg" width="500" />
 
-JPEG Visual Repair Tool can load JPEG images while preserving MCU (Minimum Coded Unit) coding data and allows editing at MCU level; the main purpose is to repair corrupted images.
-It is written in JavaScript and resides in a single [html document](JPEGVisualRepairTool.html); it can be simply saved for offline use, there are no library dependencies. 
-It is based on [jpeg-decomp](https://github.com/albmac/jpeg-decomp).
+JPEG Visual Repair Tool, based on [jpeg-decomp](https://github.com/albmac/jpeg-decomp), can load JPEG images while preserving MCU (Minimum Coded Unit) coding data and allows editing at MCU level; the main purpose is to repair corrupted images.
+It is written in JavaScript and resides in a single [html document](JPEGVisualRepairTool.html); it can be simply saved for offline use, there are no library dependencies.
 
 Using it you can:
 


### PR DESCRIPTION
This is meant to in part address #5. It improves the README.md by adding a link to the github pages url, removes extraneous ending img tags (which were being displayed on GIthub pages), and combining a sentence.

NOTE: This does not enable Github pages, nor can it. To enable Github pages for this repository, go to the repository settings -> "Code and automation" -> Pages -> Branch -> click dropdown and select "main" branch. This [link](https://github.com/albmac/JPEGVisualRepairTool/settings/pages) should take you directly to the Page settings. Here's what it looks like from [my repo](https://crass.github.io/JPEGVisualRepairTool/JPEGVisualRepairTool.html). Also going directly to the [repo page](https://crass.github.io/JPEGVisualRepairTool) shows the readme, and from that page there is a link to the tool.

There's a kind of redundancy that I don't particularly like when on the main page of the repo github pages page with having two links to the tool's html document, one relative and one absolute. The rendering is different on the markdown rendering of the README.md, where one link goes to the source of the tool and the other goes to the github pages rendering of the tool.

It could be nice to add the link to the repository description as well.