### PR TITLE
Fix NaN values in MCU when clicking "Set DC" while no value is in custom input box

### DIFF
--- a/JPEGVisualRepairTool.html
+++ b/JPEGVisualRepairTool.html
@@ -891,7 +891,10 @@ function DCmodMCU(value=1){
 		undoList.push({action: "DC", position: selectedMCU.i, cell: structuredClone(MCUarray[selectedMCU.i])});
 		if(value==0){
 			var newDC=parseInt(document.getElementById("dcVal").value);
-			if(document.getElementById("layer").value=="Y"){
+			if (Number.isNaN(parseInt(newDC))) {
+				; // no value or invalid value
+			}
+			else if(document.getElementById("layer").value=="Y"){
 				MCUarray[selectedMCU.i].blocks[0].coeff[0]=newDC;
 			}
 			else if(document.getElementById("layer").value=="C1"){


### PR DESCRIPTION
This fixes #2. If the value of the input box can not be parsed as an integer, then do nothing.